### PR TITLE
Added option to exclude learner events from output [#176773793]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "log-manager-puller",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-manager-puller",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Pulls data from the log manager",
   "main": "index.js",
   "scripts": {

--- a/views/portal-report.pug
+++ b/views/portal-report.pug
@@ -121,6 +121,12 @@ html
           | No
           input(type='radio', name='filterTEEvents', value='yes')
           | Yes
+        p
+          label(for='explode') Exclude Learner events
+          input(type='radio', name='excludeLearnerEvents', value='no', checked=1)
+          | No
+          input(type='radio', name='excludeLearnerEvents', value='yes')
+          | Yes
         p.buttons
           input(type='submit', name='download', value='Download Logs')
           if allowDebug


### PR DESCRIPTION
This is useful to only get the teacher events from a runnable, just as for portal-report log messages.