### PR TITLE
Add support of AP activities and sequences

### DIFF
--- a/test/generate-query-from-users.test.js
+++ b/test/generate-query-from-users.test.js
@@ -5,8 +5,10 @@ const users = [
   {id: 2, login: "scott", first_name: "Scott", last_name: "Cytacki"},
 ]
 const runnables = [
-  {id: 1, lara_id: 1000, url: "http://authoring.concord.org/activities/1000", name: "First Activity", source_type: "LARA"},
-  {id: 2, lara_id: 1001, url: "http://authoring.concord.org/activities/1001", name: "Second Activity", source_type: "LARA"}
+  {id: 1, url: "http://authoring.concord.org/activities/1000", name: "LARA Activity", source_type: "LARA"},
+  {id: 2, url: "http://authoring.concord.org/sequences/1001", name: "LARA Sequence", source_type: "LARA"},
+  {id: 3, url: "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F1002.json", name: "AP Activity", source_type: "ActivityPlayer"},
+  {id: 4, url: "https://activity-player.concord.org/?sequence=https://authoring.concord.org/api/v1/sequences/1003.json", name: "AP Sequence", source_type: "ActivityPlayer"}
 ]
 
 describe("generateQueryFromUsers", () => {
@@ -37,13 +39,13 @@ describe("generateQueryFromUsers", () => {
 
   test("should handle a runnables query", () => {
     const params = {domain: "example.com", users: [], runnables, start_date: null, end_date: null}
-    const result = {queryMarkers: "(activity = $1 OR activity = $2)", queryValues: ["activity: 1000", "activity: 1001"]};
+    const result = {queryMarkers: "(activity = $1 OR activity = $2 OR activity = $3 OR activity = $4)", queryValues: ["activity: 1000", "sequence: 1001", "activity: 1002", "sequence: 1003"]};
     expect(generateQueryFromUsers(params)).toMatchObject(result);
   });
 
   test("should handle a combined query", () => {
     const params = {domain: "example.com", users: users, runnables, start_date: "01/02/19", end_date: "03/04/19"}
-    const result = {queryMarkers: "(username = $1 OR username = $2) AND (activity = $3 OR activity = $4) AND time >= $5 AND time <= $6", queryValues: ["1@example.com", "2@example.com", "activity: 1000", "activity: 1001", "19-01-02", "19-03-04"]};
+    const result = {queryMarkers: "(username = $1 OR username = $2) AND (activity = $3 OR activity = $4 OR activity = $5 OR activity = $6) AND time >= $7 AND time <= $8", queryValues: ["1@example.com", "2@example.com", "activity: 1000", "sequence: 1001", "activity: 1002", "sequence: 1003", "19-01-02", "19-03-04"]};
     expect(generateQueryFromUsers(params)).toMatchObject(result);
   });
 


### PR DESCRIPTION
This PR adds support of AP activities and sequences.
I've removed source_type filtering after asking @scytacki about it. There's some inconsistency between AP activities and AP sequence URL encoding, but actually we need the same regexp even when it's fixed - so we can support both AP and LARA URLs. I kept regexp as simple as possible, as it might help with adding other tools in the future. We won't have to update log-puller each time a new tool is added unless it uses some super-specific URL format. The expected pattern is activity/<ID> or sequence/<ID> (or encoded version with %2F instead of /).

@scytacki, in one of the PT comments you mentioned:
> The log puller looks at the offering's activity_url , parses the id out of it and constructs the activity: [id] string:
> Here is the parsing:
> https://github.com/concord-consortium/log-puller/blob/59ce65c3bc5e227d794762178a491156148cfb92/app.js#L177-L185
> Here is the string construction:
> https://github.com/concord-consortium/log-puller/blob/59ce65c3bc5e227d794762178a491156148cfb92/app.js#L201
> **Looking at this, it is clear that a LARA sequence will also not work**.
> And AP activities don't work because the /\/activities\/(\d+)$/ pattern won't match the offering.activity_url

Actually, parsing for user reports happens in a different place (the function modified by this PR). And this function was already supporting LARA sequences, as there was already `sequenceMatch`.

The function you mentioned in this comment is only used here:
https://github.com/concord-consortium/log-puller/blob/dd34dc84e01229f876b00e924e654577b4b09ecf/app.js#L572-L578
I don't know when these routes are used and if we need to change anything there. But it doesn't seem to be related to portal-report page/form that handles queries and download in a different way:
https://github.com/concord-consortium/log-puller/blob/dd34dc84e01229f876b00e924e654577b4b09ecf/app.js#L593-L609
 
